### PR TITLE
fix: disable experimental setting  on automatic context attachment in Agent Mode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,9 @@
       "settings": {
         "livePreview.openPreviewTarget": "External Browser",
         
+        // This experimental (as of 2 Sept) feature disables the automatic context attachment of current active file in Agent Mode
+        "chat.implicitContext.suggestedContext": false,
+
         // These are defaults but keeping them here for clarity and explicitness
         "github.copilot.chat.codeGeneration.useInstructionFiles": true,
         "chat.promptFilesLocations": {


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

A new experimental feature was added within last months in Agent Mode that impact the implicit context flow.
VSCode: https://github.com/microsoft/vscode/pull/254768
Docs: https://github.com/microsoft/vscode-docs/commit/c927880f72e1af38b4e4575bd5a9a7953eafc726

The tl;dr change is -> in Agent Mode, the current active file is no longer automatically attached as context. Instead Agent Mode "determines" if it should be attached.


This exercise contains a prompt that says `Update this assignment file ...` and recent test by @chrisreddington  have shown that agent mode does not pick up the currently opened assignment file, therefore also not picking up the instruction files for that file type

Actual:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/db6aa7ec-ce01-41d6-a095-7344dfc056e4" />

Expected:
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/4bc32d4d-2c2a-4958-825f-df92781a8cca" />


### Changes
<!-- Describe the changes this pull request introduces. -->

This is a simple, band aid fix to disable this new feature. Let's talk about this, see if other exercises are affected and how we want to proceed.

If this feature is here to stay, we may want to add additional step explaining it and possibly asking the user to manually attach the current file.


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
