### PR TITLE
Update references from skills-dev to skills organization

### DIFF
--- a/.github/steps/x-review.md
+++ b/.github/steps/x-review.md
@@ -17,4 +17,4 @@ Take another GitHub Skills exercise on [GitHub Learn](https://learn.github.com/s
 
 - [Integrate MCP with Copilot](https://github.com/skills/integrate-mcp-with-copilot) - Learn how to extend Copilot with Model Context Protocol. You will learn about MCP tools which can also be used in custom agents and prompts!
 - [Modernize Legacy Code](https://github.com/skills/modernize-your-legacy-code-with-github-copilot) - Use Copilot to help refactor and improve existing codebases.
-- [GitHub Pages](https://github.com/skills-dev/github-pages) - Learn how to publish static website's like the one in this exercise.
+- [GitHub Pages](https://github.com/skills/github-pages) - Learn how to publish static website's like the one in this exercise.


### PR DESCRIPTION
## Summary

This PR updates all references from the `skills-dev` organization to the `skills` organization.

## Context

We have merged all repositories from the `skills-dev` organization into the main `skills` organization. This PR updates any links and references that still point to `skills-dev` to ensure they point to the correct organization.

## Changes

- Updated repository references from `skills-dev` to `skills`
- No functional changes, only URL/reference updates