### PR TITLE
docs: update tool name from 'fetch' to 'web' in Step 4's agent.md example

### DIFF
--- a/.github/steps/4-step.md
+++ b/.github/steps/4-step.md
@@ -31,7 +31,7 @@ Now let's create a specialized custom agent for brainstorming assignment ideas.
    ---
    name: assignment-brainstorming
    description: Assignment brainstorming assistant
-   tools: ["search", "fetch"]
+   tools: ["search", "web"]
    ---
 
    # 💡 Assignment Brainstorming Assistant


### PR DESCRIPTION
### Summary
fix the warning sign appeared when the agent.md content example in Step 4  is applied


### Changes
Update the `assignment-brainstorming.agent.md` example in `.github/steps/4-step.md` to reflect the tool name change from 'fetch' to 'web'.

The '`fetch`' tool has been superseded by '`web_fetch`' (referenced as '`web`') for retrieving web content in Copilot workflows.

Ref: [GitHub Copilot CLI: Enhanced agents, context management, and new ways to install](https://github.blog/changelog/2026-01-14-github-copilot-cli-enhanced-agents-context-management-and-new-ways-to-install/)

Closes: #27 

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
